### PR TITLE
Added Unity TDD Tests and cleaned up pfio.h to be a minimal interface

### DIFF
--- a/c/src/piface/pfio.h
+++ b/c/src/piface/pfio.h
@@ -6,65 +6,17 @@
 extern "C" {
 #endif
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <linux/spi/spidev.h>
-#include <linux/types.h>
-#include <sys/ioctl.h>
+#include <stdint.h>
 
-// /dev/spidev<BUS>.<DEVICE>
-#define SPI_BUS    0
-#define SPI_DEVICE 0
-#define MAXPATH    16
-
-#define TRANSFER_LEN   3
-#define TRANSFER_DELAY 5
-#define TRANSFER_SPEED 1000000
-#define TRANSFER_BPW   8
-
-#define SPI_WRITE_CMD 0x40
-#define SPI_READ_CMD 0x41
-
-// Port configuration
-#define IODIRA 0x00 // I/O direction A
-#define IODIRB 0x01 // I/O direction B
-#define IOCON  0x0A // I/O config
-#define GPIOA  0x12 // port A
-#define GPIOB  0x13 // port B
-#define GPPUA  0x0C // port A pullups
-#define GPPUB  0x0D // port B pullups
-#define OUTPUT_PORT GPIOA
-#define INPUT_PORT  GPIOB
-
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
-
-typedef struct
-{
-    int fd;          // open file descriptor: /dev/spi-X.Y
-    int mode;        // current SPI mode
-    int bitsperword; // current SPI bits per word setting
-    int maxspeed;    // current SPI max speed setting in Hz
-} Spi;
-
-
-extern char pfio_init(void);
-extern char pfio_deinit(void);
-extern char pfio_digital_read(char pin_number);
-extern void pfio_digital_write(char pin_number, char value);
-extern char pfio_read_input(void);
-extern char pfio_read_output(void);
-extern void pfio_write_output(char value);
-extern char pfio_get_pin_bit_mask(char pin_number);
-extern char pfio_get_pin_number(char bit_mask);
-
-/*
-static void spi_transfer(char * txbuffer, char * rxbuffer);
-static void spi_write(char port, char value);
-static char spi_read(char port);
-*/
+int     pfio_init(void);
+int     pfio_deinit(void);
+uint8_t pfio_digital_read(uint8_t pin_number);
+void    pfio_digital_write(uint8_t pin_number, uint8_t value);
+uint8_t pfio_read_input(void);
+uint8_t pfio_read_output(void);
+void    pfio_write_output(uint8_t value);
+uint8_t pfio_get_pin_bit_mask(uint8_t pin_number);
+uint8_t pfio_get_pin_number(uint8_t bit_mask);
 
 #ifdef __cplusplus
 }

--- a/c/unitytest/Makefile
+++ b/c/unitytest/Makefile
@@ -1,0 +1,26 @@
+# ==========================================
+#   Unity Project - A Test Framework for C
+#   Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+#   [Released under MIT License. Please refer to license.txt for details]
+# ========================================== 
+
+C_COMPILER=gcc
+TARGET = tests
+OUT_FILE=-o $(TARGET)
+SRC_FILES=/usr/share/cmock/vendor/unity/src/unity.c test/$(TARGET).c build/$(TARGET)_Runner.c ../src/piface/pfio.c
+INC_DIRS=-I/usr/share/cmock/vendor/unity/src/ -I../src/piface/
+SYMBOLS=-DTEST -DUNITY_SUPPORT_64 -std=c99
+
+CLEANUP = rm -f build/*.o ; rm -f $(TARGET)
+
+all: clean default
+
+default:
+	ruby /usr/share/cmock/vendor/unity/auto/generate_test_runner.rb test/$(TARGET).c build/$(TARGET)_Runner.c
+	$(C_COMPILER) $(INC_DIRS) $(SYMBOLS) $(SRC_FILES) $(OUT_FILE)
+	clear
+	./$(TARGET)
+
+clean:
+	$(CLEANUP)
+	

--- a/c/unitytest/README.md
+++ b/c/unitytest/README.md
@@ -1,0 +1,21 @@
+USING UNITY FOR Piface C Interace Refactoring (pfio.h & pfio.c)
+
+1. Download CMock (which includes Unity) to an approriate directory. The Makefile assumes it has been put into /usr/share but CMock can be locaed anywhere
+$ wget http://downloads.sourceforge.net/project/cmock/cmock/cmock2.0/cmock_2_0_204.zip
+$ unzip cmock_2_0_204.zip
+
+2. You should now find a directory cmock; the unity files are found under cmock/vendor/unity
+
+3. Install ruby
+$ sudo apt-get instal ruby
+
+4. The Unity test file is found at piface/c/unitytest/test/tests.c
+
+5. To run the tests, in the unitytest directory type
+$ make
+
+6. Unity automatically builds a new test main() function and executes the tests
+
+NOTE
+To use the automatic test hardess, then you will need to wire output.0 to input.0, output.1 to input.1, etc.
+

--- a/c/unitytest/test/tests.c
+++ b/c/unitytest/test/tests.c
@@ -1,0 +1,119 @@
+#include "unity.h"
+#include "pfio.h"
+#include <stdint.h>
+
+void setUp(void)
+{
+   uint8_t result = pfio_init();
+   TEST_ASSERT_EQUAL_INT(0,result);
+}
+
+void tearDown(void)
+{
+   uint8_t result = pfio_deinit();
+   TEST_ASSERT_EQUAL_INT(0,result);
+}
+
+void testInit(void)
+{
+   uint8_t result = pfio_read_output();
+   TEST_ASSERT_BITS_LOW_MESSAGE(0xFF, result, "default outputs not all low");
+}
+
+void testDigitalWrite0(void)
+{
+   pfio_digital_write(0, 1);
+   uint8_t result = pfio_read_output();
+   TEST_ASSERT_BIT_HIGH_MESSAGE(0, result, "pin 0 output not set");
+   pfio_digital_write(0, 0);
+   result = pfio_read_output();
+   TEST_ASSERT_BIT_LOW_MESSAGE(0, result, "pin 0 output not cleared");
+}
+
+void testDigitalWriteAll(void)
+{
+   for(uint8_t pin = 0; pin < 8; ++pin) {
+	pfio_digital_write(pin, 1);
+	uint8_t result = pfio_read_output();
+   	TEST_ASSERT_BIT_HIGH_MESSAGE(pin, result, "output not set");
+   	pfio_digital_write(pin, 0);
+   	result = pfio_read_output();
+        TEST_ASSERT_BIT_LOW_MESSAGE(pin, result, "output not cleared");
+   }
+}
+
+void testWriteOutputAll(void)
+{
+   pfio_write_output(0xFF);
+   uint8_t result = pfio_read_output();
+   TEST_ASSERT_BITS_HIGH_MESSAGE(0xFF, result, "outputs not set");
+   pfio_write_output(0);
+   result = pfio_read_output();
+   TEST_ASSERT_BITS_LOW_MESSAGE(0xFF, result, "outputs not cleared");
+}
+
+void testWriteOutputByBit(void)
+{
+   for(uint8_t pin = 0; pin < 8; ++pin) {
+        pfio_write_output(1 << pin);
+        uint8_t result = pfio_read_output();
+        TEST_ASSERT_BIT_HIGH_MESSAGE(pin, result, "output not set");
+        pfio_write_output(0);
+   }
+}
+
+void testDigitalRead0(void)
+{
+   pfio_digital_write(0, 1);
+   uint8_t result = pfio_digital_read(0);
+   TEST_ASSERT_EQUAL_INT(1,result);
+   pfio_digital_write(0, 0);
+   result = pfio_digital_read(0);
+   TEST_ASSERT_EQUAL_INT(0,result);
+}
+
+void testDigitalReadByBit(void)
+{
+   for(uint8_t pin = 0; pin < 8; ++pin) {
+        pfio_digital_write(pin, 1);
+        uint8_t result = pfio_digital_read(pin);
+        TEST_ASSERT_EQUAL_INT(1,result);
+        pfio_digital_write(pin, 0);
+        result = pfio_digital_read(pin);
+        TEST_ASSERT_EQUAL_INT(0,result);
+   }
+}
+
+void testDigitalReadInput(void)
+{
+   pfio_write_output(0xFF);
+   uint8_t result = pfio_read_input();
+   TEST_ASSERT_BITS_HIGH_MESSAGE(0xFF, result, "outputs not set");
+   pfio_write_output(0);
+   result = pfio_read_input();
+   TEST_ASSERT_BITS_LOW_MESSAGE(0xFF, result, "outputs not cleared");
+}
+
+
+/*
+extern char pfio_init(void);
+- pfio_init twice
+
+extern char pfio_deinit(void);
+- pfio_deinit twice
+
+extern char pfio_digital_read(char pin_number);
+- pin_number > 7
+- -ve pin_number
+- 
+
+extern void pfio_digital_write(char pin_number, char value);
+- pin_number > 7
+- -ve pin_number
+- value > 1
+- value < 0
+
+extern char pfio_read_input(void);
+extern char pfio_read_output(void);
+extern void pfio_write_output(char value);
+*/


### PR DESCRIPTION
Hi Thomas, 
I've just started playing with the piface and was looking at your supplied C wrapper functions. 
I've had a go at cleaning them up. Initially fairly simple (i.e. you should never use char for 8-bit data as it's neither signed or unsigned) and used the useful C header <stdint.h> for uint8_t as a better type for byte data.
I removed all the stuff from the header that shouldn't really be there (you only put stuff in a header of use to the client).
I haven't changed any basic behaviour but have some plans.
If you've never see Unity as a C based TDD framework it's vey useful.
Thanks for doing the difficult bit,
Regards, Niall.
