### PR TITLE
Fixed the wrong include path in the pkg-config database file

### DIFF
--- a/c/piface-1.0.pc.in
+++ b/c/piface-1.0.pc.in
@@ -8,4 +8,4 @@ Description: C interface for the PiFace Raspberry Pi add on.
 Requires:
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lpiface-1.0
-Cflags: -I${includedir}/piface-1.0 -I${libdir}/piface-1.0/include
+Cflags: -I${includedir}/libpiface-1.0 -I${libdir}/libpiface-1.0/include


### PR DESCRIPTION
The path changed from (inlcudepath)/piface-1.0 to
(includepath)/libpiface-1.0 according the the installation path in the
Makefile.am
